### PR TITLE
disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     ignore:
       - dependency-name: "electron"
       - dependency-name: "spectron"


### PR DESCRIPTION
From my reading and understanding, there is a difference between **security updates** and regular **version updates**.

You can read more [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates#:~:text=for%20information%20about%20enabling%20security%20updates%2C%20see%20%22configuring%20dependabot%20security%20updates.%22).

The version upgrades are noisy, of course.