### PR TITLE
Build: the macOS-13 runner images are retired

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
         fail-fast: false
         matrix:
           os:
-            - macos-13
             - macos-latest
             - ubuntu-latest
             - windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
           - macos-latest
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
For more details, see https://github.com/actions/runner-images/issues/13046.