### PR TITLE
fix(scripts): strip ELECTRON_RUN_AS_NODE before spawning Electron

### DIFF
--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -67,4 +67,7 @@ if (mainNeedsRebuild || preloadNeedsRebuild) {
 }
 
 console.log('Starting scrape...');
-execSync('electron . --scrape', { stdio: 'inherit', cwd: projectRoot });
+// Strip ELECTRON_RUN_AS_NODE — VSCode terminals inherit it and it forces Node-only mode.
+const childEnv = { ...process.env };
+delete childEnv.ELECTRON_RUN_AS_NODE;
+execSync('electron . --scrape', { stdio: 'inherit', cwd: projectRoot, env: childEnv });

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -45,8 +45,12 @@ function setupMainPackageWatcher({ resolvedUrls }) {
           }
 
           /** Spawn new electron process */
+          // Strip ELECTRON_RUN_AS_NODE — VSCode terminals inherit it and it forces Node-only mode.
+          const childEnv = { ...process.env };
+          delete childEnv.ELECTRON_RUN_AS_NODE;
           electronApp = spawn(String(electronPath), ['--inspect', '.'], {
             stdio: 'inherit',
+            env: childEnv,
           });
 
           /** Stops the watch script when the application has been quit */


### PR DESCRIPTION
VSCode is itself an Electron app and sets ELECTRON_RUN_AS_NODE=1 in its terminal/extension-host environment. When `yarn watch` or `yarn scrape` are run from a VSCode integrated terminal, that var inherits down to the Electron child, forcing it into Node-only mode. The result: `import { app } from 'electron'` (and `require('electron')`) fail with "does not provide an export named 'app'", because the GUI Electron runtime never initializes.

Strip the var from the spawn env in both scripts. No effect on the postinstall script, which sets it explicitly via cross-env.