### PR TITLE
Fix: skip deleted YNAB transactions in duplicate detection

### DIFF
--- a/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
+++ b/packages/main/src/backend/export/outputVendors/ynab/ynab.ts
@@ -224,9 +224,9 @@ async function filterOnlyTransactionsThatDontExistInYnabAlready(
   }
   const transactionsThatDontExistInYnab = transactionsFromFinancialAccounts.filter(
     (transactionToCheck) =>
-      !transactionsInYnabBeforeCreatingTheseTransactions.find((existingTransaction) =>
-        isSameTransaction(transactionToCheck, existingTransaction),
-      ),
+      !transactionsInYnabBeforeCreatingTheseTransactions
+        .filter((t) => !t.deleted)
+        .find((existingTransaction) => isSameTransaction(transactionToCheck, existingTransaction)),
   );
   return transactionsThatDontExistInYnab;
 }


### PR DESCRIPTION
YNAB's transactions API returns deleted transactions with deleted:true. The duplicate detection was matching against them by import_id, so transactions deleted from YNAB could not be re-imported (Caspion treated them as already existing). Now filters them out before the import_id check.